### PR TITLE
Add Proveedor class with CRUD utilities

### DIFF
--- a/Proveedor.py
+++ b/Proveedor.py
@@ -1,0 +1,65 @@
+class Proveedor:
+    """Representa a un proveedor."""
+
+    def __init__(self, identificacion, nombre, direccion, representante, correo, telefono):
+        self.identificacion = identificacion
+        self.nombre = nombre
+        self.direccion = direccion
+        self.representante = representante
+        self.correo = correo
+        self.telefono = telefono
+
+        self.validar_identificacion(identificacion)
+        self.validar_campo_texto(nombre, "nombre")
+        self.validar_campo_texto(direccion, "direccion")
+        self.validar_campo_texto(representante, "representante")
+        self.validar_correo(correo)
+        self.validar_campo_texto(telefono, "telefono")
+
+    @staticmethod
+    def validar_identificacion(identificacion):
+        if not isinstance(identificacion, int) or identificacion <= 0:
+            raise ValueError("La identificacion debe ser un numero entero positivo.")
+
+    @staticmethod
+    def validar_campo_texto(valor, campo):
+        if not valor or not isinstance(valor, str) or valor.strip() == "":
+            raise ValueError(f"El campo '{campo}' no puede estar vacio.")
+
+    @staticmethod
+    def validar_correo(correo):
+        import re
+        patron = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+        if not re.match(patron, correo):
+            raise ValueError("El correo electronico no tiene un formato valido.")
+
+
+class ProveedorDB:
+    """Base de datos simulada para proveedores."""
+
+    def __init__(self):
+        self.proveedores = {}
+
+    def agregar_proveedor(self, proveedor):
+        if proveedor.identificacion in self.proveedores:
+            raise ValueError(f"Ya existe un proveedor con el ID {proveedor.identificacion}.")
+        self.proveedores[proveedor.identificacion] = proveedor
+
+    def obtener_proveedor_por_id(self, proveedor_id):
+        return self.proveedores.get(proveedor_id, None)
+
+    def actualizar_proveedor(self, proveedor_id, **kwargs):
+        if proveedor_id not in self.proveedores:
+            raise ValueError(f"No existe un proveedor con el ID {proveedor_id}.")
+        proveedor = self.proveedores[proveedor_id]
+        for key, value in kwargs.items():
+            if hasattr(proveedor, key):
+                setattr(proveedor, key, value)
+            else:
+                raise ValueError(f"El campo '{key}' no es valido para un proveedor.")
+
+    def eliminar_proveedor(self, proveedor_id):
+        if proveedor_id not in self.proveedores:
+            raise ValueError(f"No existe un proveedor con el ID {proveedor_id}.")
+        del self.proveedores[proveedor_id]
+

--- a/test_proveedor.py
+++ b/test_proveedor.py
@@ -1,0 +1,61 @@
+import pytest
+from Proveedor import Proveedor, ProveedorDB
+
+
+def test_crear_proveedor_ok():
+    p = Proveedor(1, "ABC", "Calle 1", "Juan Perez", "abc@example.com", "1234")
+    assert p.identificacion == 1
+    assert p.nombre == "ABC"
+
+
+def test_crear_proveedor_id_invalido():
+    with pytest.raises(ValueError):
+        Proveedor(0, "ABC", "Calle 1", "Juan Perez", "abc@example.com", "1234")
+
+
+@pytest.fixture
+def db_vacia():
+    return ProveedorDB()
+
+
+@pytest.fixture
+def proveedor_ok():
+    return Proveedor(2, "XYZ", "Calle 2", "Ana Lopez", "xyz@example.com", "5678")
+
+
+def test_agregar_proveedor_ok(db_vacia, proveedor_ok):
+    db_vacia.agregar_proveedor(proveedor_ok)
+    assert db_vacia.obtener_proveedor_por_id(2) is not None
+
+
+def test_agregar_proveedor_duplicado(db_vacia, proveedor_ok):
+    db_vacia.agregar_proveedor(proveedor_ok)
+    with pytest.raises(ValueError):
+        db_vacia.agregar_proveedor(proveedor_ok)
+
+
+def test_obtener_proveedor_inexistente(db_vacia):
+    assert db_vacia.obtener_proveedor_por_id(99) is None
+
+
+def test_actualizar_proveedor_ok(db_vacia, proveedor_ok):
+    db_vacia.agregar_proveedor(proveedor_ok)
+    db_vacia.actualizar_proveedor(2, nombre="XYZ2")
+    assert db_vacia.obtener_proveedor_por_id(2).nombre == "XYZ2"
+
+
+def test_actualizar_proveedor_inexistente(db_vacia):
+    with pytest.raises(ValueError):
+        db_vacia.actualizar_proveedor(3, nombre="No")
+
+
+def test_eliminar_proveedor_ok(db_vacia, proveedor_ok):
+    db_vacia.agregar_proveedor(proveedor_ok)
+    db_vacia.eliminar_proveedor(2)
+    assert db_vacia.obtener_proveedor_por_id(2) is None
+
+
+def test_eliminar_proveedor_inexistente(db_vacia):
+    with pytest.raises(ValueError):
+        db_vacia.eliminar_proveedor(5)
+


### PR DESCRIPTION
## Summary
- implement `Proveedor` class for supplier handling with CRUD functions
- add unit tests for new class

## Testing
- `pytest -q test_proveedor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models'; ModuleNotFoundError: No module named 'requests'; IndentationError in test_conversor.py)*

------
https://chatgpt.com/codex/tasks/task_e_68673c071e84832b8b9de3078792d1f0